### PR TITLE
gitpod conf

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: bundle install


### PR DESCRIPTION
fix error on HQL example.

fetch is not used fuel in this specific case because we do not need to load the whole associated entity (Department)